### PR TITLE
Mark a listening socket as bad if we can't accept() from it

### DIFF
--- a/rinetd.c
+++ b/rinetd.c
@@ -948,6 +948,7 @@ void handleAccept(int i)
 	addrlen = sizeof(addr);
 	SOCKET nfd = accept(srv->fd, &addr, &addrlen);
 	if (nfd == INVALID_SOCKET) {
+		srv->fd = INVALID_SOCKET;
 		syslog(LOG_ERR, "accept(%d): %m", srv->fd);
 		logEvent(NULL, i, logAcceptFailed);
 		return;


### PR DESCRIPTION
Hi,

My logs were full of

    accept(0, 0x7fffb997d7d0, [16])         = -1 ENOTSOCK (Socket operation on non-socket)
    sendto(38, "<27>Feb  3 14:34:15 rinetd[9382]"..., 75, MSG_NOSIGNAL, NULL, 0) = 75

where rinetd was trying to accept on fd 0, which wasn't a listening socket. Other code paths set the fd to `INVALID_SOCKET` on error, so I've added the same line to `handleAccept`.

I can confirm this fixed my issue in production.