### PR TITLE
Change _DEFAULT_SOURCE for _GNU_SOURCE to enable building on glibc 2.15

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,6 @@ rinetd_SOURCES = rinetd.c match.c match.h
 
 # _POSIX_C_SOURCE is for SA_RESTART and others
 # _XOPEN_SOURCE is for struct sigaction
-# _DEFAULT_SOURCE is for h_errno and gethostbyname-related macros
-rinetd_CFLAGS = -std=c99 -D_XOPEN_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L -Wall -Wextra -Wwrite-strings -I.
+# _GNU_SOURCE is for h_errno and gethostbyname-related macros
+rinetd_CFLAGS = -std=c99 -D_XOPEN_SOURCE -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -Wall -Wextra -Wwrite-strings -I.
 


### PR DESCRIPTION
Hi,

As per #2, older glibc versions also require `_GNU_SOURCE` (which implies `_DEFAULT_SOURCE`) to build. This allowed me to build on Ubuntu 12.04 (glibc 2.15).
