### PR TITLE
Add lost item to array of logMessages

### DIFF
--- a/src/rinetd.c
+++ b/src/rinetd.c
@@ -90,6 +90,7 @@ char const *logMessages[] = {
 	"local-bind-failed -",
 	"local-connect-failed -",
 	"opened",
+	"allowed",
 	"not-allowed",
 	"denied",
 };


### PR DESCRIPTION
The "logMessages" array in the rinetd.c file is missing an item "allowed"