### PR TITLE
Added setsockopt(SOL_SOCKET, SO_KEEPALIVE)

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -31,6 +31,10 @@ void setSocketDefaults(SOCKET fd) {
 	int tmp = 1024;
 	setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &tmp, sizeof(tmp));
 #endif
+	{
+		int tmp= 1;
+		setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &tmp, sizeof(tmp));
+	}
 }
 
 int getAddrInfoWithProto(char *address, char *port, int protocol, struct addrinfo **ai)

--- a/src/net.c
+++ b/src/net.c
@@ -32,7 +32,7 @@ void setSocketDefaults(SOCKET fd) {
 	setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &tmp, sizeof(tmp));
 #endif
 	{
-		int tmp= 1;
+		int tmp = 1;
 		setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &tmp, sizeof(tmp));
 	}
 }


### PR DESCRIPTION
It's strange I have never realized it so far: there is no `setsockopt(SOL_SOCKET, SO_KEEPALIVE)` in rinetd. (I've been using it since 2003.)